### PR TITLE
Export zmpl in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const zmpl = @import("src/zmpl.zig");
+pub const zmpl = @import("src/zmpl.zig");
 
 // Although this function looks imperative, note that its job is to
 // declaratively construct a build graph that will be executed by an external


### PR DESCRIPTION
This allows generation to be run during compilation by referencing it in another project's build.zig