### PR TITLE
Support windows CLRF new lines

### DIFF
--- a/src/zmpl/Template.zig
+++ b/src/zmpl/Template.zig
@@ -29,6 +29,8 @@ const MarkupLine = struct {
 
     pub fn compile(self: *MarkupLine) ![]const u8 {
         for (self.line) |byte| {
+            if (byte == '\r') continue;
+
             if (byte == '\\' and !self.escape) {
                 self.escape = true;
                 continue;


### PR DESCRIPTION
By ignoring \r on CLRF new lines.

I was going to create a test case but I saw all your test cases were instructive examples and a test for CLRF didn't make sense. 

I pulled in your files directly in my project and I made this change [in my version](https://github.com/btipling/blockens/commit/32685b18a69d52ddb33013a1d7c6b9b36508bb01#diff-a26af6d0386098bca752b8dd87b83ef20f533bda20eecca2214ba30c323f99fcR32) of your code. It's fine if this isn't the approach that works for this project, I thought I'd create a PR anyway. Really great library.

Unrelated but I noticed if I created a `test.zmpl` it will generate invalid zig code in the manifest.

Also I might patch this to clear out currently generated compiled.zig's for each build for those that weren't found? 

Thanks so much for this great template library!