### PR TITLE
Use pointers for all Zmpl Data objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ test "readme example" {
     try user.put("email", data.string("user@example.com"));
     try auth.put("token", data.string("abc123-456-def"));
 
-    try body.put("user", user.*);
-    try body.put("auth", auth.*);
+    try body.put("user", user);
+    try body.put("auth", auth);
 
     const output = try manifest.templates.example.render(&data);
     defer allocator.free(output);

--- a/src/templates/example_with_complex_content.zmpl
+++ b/src/templates/example_with_complex_content.zmpl
@@ -17,7 +17,7 @@
   </div>
 
   <ol>
-    if (zmpl.value) |*value| {
+    if (zmpl.value) |value| {
       var it = value.array.iterator();
 
       while (it.next()) |item| {


### PR DESCRIPTION
Allow inserting mutable arrays/objects into data object, fixes issue where an array/object could be inserted into another array/object and then later modified (changes would not take effect).