### PR TITLE
Implement partial arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ if (std.mem.eql(u8, "zmpl is simple", "zmpl" ++ " is " ++ "simple")) {
   // Render a partial named `users/_mailto.zmpl`:
   <div>{^users/mailto}</div>
 
+  // Pass arguments to a partial:
+  <div>{^users/mailto(subject: zmpl.string("Welcome to Jetzig!"))}</div>
+
   <>Use fragment tags when you want to output content without a specific HTML tag</>
 
   <#>
@@ -65,10 +68,16 @@ test "readme example" {
         try std.testing.expectEqualStrings(
             \\  <div>Email: user@example.com</div>
             \\  <div>Token: abc123-456-def</div>
-            \\  <div><a href="mailto:user@example.com">user@example.com</a></div>
+            \\
+            \\  <div><a href="mailto:user@example.com?subject=">user@example.com</a></div>
+            \\
+            \\  <div><a href="mailto:user@example.com?subject=Welcome to Jetzig!">user@example.com</a></div>
+            \\
             \\  Use fragment tags when you want to output content without a specific HTML tag
+            \\
             \\  Use multi-line raw text tags to bypass Zmpl syntax.
             \\  <code>Some example code with curly braces {} etc.</code>
+            \\
             \\  <span>Escape curly braces {like this}</span>
             \\
         , output);

--- a/src/templates/_example_partial_with_arguments.zmpl
+++ b/src/templates/_example_partial_with_arguments.zmpl
@@ -1,0 +1,3 @@
+<span>An example partial</span>
+<span>foo: {.foo}</span>
+<span>bar: {.bar}</span>

--- a/src/templates/example.zmpl
+++ b/src/templates/example.zmpl
@@ -6,6 +6,9 @@ if (std.mem.eql(u8, "zmpl is simple", "zmpl" ++ " is " ++ "simple")) {
   // Render a partial named `users/_mailto.zmpl`:
   <div>{^users/mailto}</div>
 
+  // Pass arguments to a partial:
+  <div>{^users/mailto(subject: zmpl.string("Welcome to Jetzig!"))}</div>
+
   <>Use fragment tags when you want to output content without a specific HTML tag</>
 
   <#>

--- a/src/templates/example_with_partial_with_arguments.zmpl
+++ b/src/templates/example_with_partial_with_arguments.zmpl
@@ -1,0 +1,2 @@
+<div>This is an example with a partial with arguments</div>
+<div>{^example_partial_with_arguments foo: zmpl.string("hello"), bar: zmpl.integer(100)}</div>

--- a/src/templates/example_with_partial_with_arguments.zmpl
+++ b/src/templates/example_with_partial_with_arguments.zmpl
@@ -1,2 +1,2 @@
 <div>This is an example with a partial with arguments</div>
-<div>{^example_partial_with_arguments foo: zmpl.string("hello"), bar: zmpl.integer(100)}</div>
+<div>{^example_partial_with_arguments(foo: zmpl.string("hello"), bar: zmpl.integer(100))}</div>

--- a/src/templates/example_with_partial_with_arguments_with_commas_in_quotes.zmpl
+++ b/src/templates/example_with_partial_with_arguments_with_commas_in_quotes.zmpl
@@ -1,2 +1,2 @@
 <div>This is an example with a partial with arguments</div>
-<div>{^example_partial_with_arguments foo: zmpl.string("hello, hi: goodbye"), bar: zmpl.integer(100)}</div>
+<div>{^example_partial_with_arguments(foo: zmpl.string("hello, hi: goodbye"), bar: zmpl.integer(100))}</div>

--- a/src/templates/example_with_partial_with_arguments_with_commas_in_quotes.zmpl
+++ b/src/templates/example_with_partial_with_arguments_with_commas_in_quotes.zmpl
@@ -1,0 +1,2 @@
+<div>This is an example with a partial with arguments</div>
+<div>{^example_partial_with_arguments foo: zmpl.string("hello, hi: goodbye"), bar: zmpl.integer(100)}</div>

--- a/src/templates/example_with_partial_with_arguments_with_escaped_quotes.zmpl
+++ b/src/templates/example_with_partial_with_arguments_with_escaped_quotes.zmpl
@@ -1,2 +1,2 @@
 <div>This is an example with a partial with arguments</div>
-<div>{^example_partial_with_arguments foo: zmpl.string("hello, hi: \"foo, bar\" goodbye"), bar: zmpl.integer(100)}</div>
+<div>{^example_partial_with_arguments(foo: zmpl.string("hello, hi: \"foo, bar\" goodbye"), bar: zmpl.integer(100))}</div>

--- a/src/templates/example_with_partial_with_arguments_with_escaped_quotes.zmpl
+++ b/src/templates/example_with_partial_with_arguments_with_escaped_quotes.zmpl
@@ -1,0 +1,2 @@
+<div>This is an example with a partial with arguments</div>
+<div>{^example_partial_with_arguments foo: zmpl.string("hello, hi: \"foo, bar\" goodbye"), bar: zmpl.integer(100)}</div>

--- a/src/templates/users/_mailto.zmpl
+++ b/src/templates/users/_mailto.zmpl
@@ -1,1 +1,1 @@
-<a href="mailto:{.user.email}">{.user.email}</a>
+<a href="mailto:{.user.email}?subject={.subject}">{.user.email}</a>

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -395,6 +395,60 @@ test "template with partial" {
     try std.testing.expectEqualStrings(expected, output);
 }
 
+test "template with partial with arguments" {
+    var data = zmpl.Data.init(allocator);
+    defer data.deinit();
+
+    const template = manifest.find("example_with_partial_with_arguments");
+    const output = try template.?.render(&data);
+    defer allocator.free(output);
+
+    const expected =
+        \\<div>This is an example with a partial with arguments</div>
+        \\<div><span>An example partial</span>
+        \\<span>foo: hello</span>
+        \\<span>bar: 100</span></div>
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "template with partial with arguments with commas and quotes" {
+    var data = zmpl.Data.init(allocator);
+    defer data.deinit();
+
+    const template = manifest.find("example_with_partial_with_arguments_with_commas_in_quotes");
+    const output = try template.?.render(&data);
+    defer allocator.free(output);
+
+    const expected =
+        \\<div>This is an example with a partial with arguments</div>
+        \\<div><span>An example partial</span>
+        \\<span>foo: hello, hi: goodbye</span>
+        \\<span>bar: 100</span></div>
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "template with partial with arguments with escaped quotes" {
+    var data = zmpl.Data.init(allocator);
+    defer data.deinit();
+
+    const template = manifest.find("example_with_partial_with_arguments_with_escaped_quotes");
+    const output = try template.?.render(&data);
+    defer allocator.free(output);
+
+    const expected =
+        \\<div>This is an example with a partial with arguments</div>
+        \\<div><span>An example partial</span>
+        \\<span>foo: hello, hi: "foo, bar" goodbye</span>
+        \\<span>bar: 100</span></div>
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
 test "template with partial with no terminating linebreak" {
     var data = zmpl.Data.init(allocator);
     defer data.deinit();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -25,7 +25,9 @@ test "readme example" {
             \\  <div>Email: user@example.com</div>
             \\  <div>Token: abc123-456-def</div>
             \\
-            \\  <div><a href="mailto:user@example.com">user@example.com</a></div>
+            \\  <div><a href="mailto:user@example.com?subject=">user@example.com</a></div>
+            \\
+            \\  <div><a href="mailto:user@example.com?subject=Welcome to Jetzig!">user@example.com</a></div>
             \\
             \\  Use fragment tags when you want to output content without a specific HTML tag
             \\
@@ -62,7 +64,7 @@ test "template with DOS linebreaks" {
             \\  <div>Email: user@example.com</div>
             \\  <div>Token: abc123-456-def</div>
             \\
-            \\  <div><a href="mailto:user@example.com">user@example.com</a></div>
+            \\  <div><a href="mailto:user@example.com?subject=">user@example.com</a></div>
             \\
             \\  Use fragment tags when you want to output content without a specific HTML tag
             \\


### PR DESCRIPTION
Allow passing arguments to partials:
```
{^example_partial foo: zmpl.string("hello"), bar: zmpl.integer(100)}
```