### PR TITLE
Implement type inference on partial args

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ if (std.mem.eql(u8, "zmpl is simple", "zmpl" ++ " is " ++ "simple")) {
   // Pass arguments to a partial:
   <div>{^users/mailto(subject: zmpl.string("Welcome to Jetzig!"))}</div>
 
+  // Pass arguments to a partial with type inference:
+  <div>{^users/mailto(subject: "Welcome to Jetzig!")}</div>
+
   <>Use fragment tags when you want to output content without a specific HTML tag</>
 
   <#>

--- a/src/templates/_example_partial_with_inferred_arguments.zmpl
+++ b/src/templates/_example_partial_with_inferred_arguments.zmpl
@@ -1,0 +1,6 @@
+<span>An example partial</span>
+<span>foo: {.foo}</span>
+<span>bar: {.bar}</span>
+<span>baz: {.baz}</span>
+<span>qux: {.qux}</span>
+<span>quux: {.quux}</span>

--- a/src/templates/example.zmpl
+++ b/src/templates/example.zmpl
@@ -9,6 +9,9 @@ if (std.mem.eql(u8, "zmpl is simple", "zmpl" ++ " is " ++ "simple")) {
   // Pass arguments to a partial:
   <div>{^users/mailto(subject: zmpl.string("Welcome to Jetzig!"))}</div>
 
+  // Pass arguments to a partial with type inference:
+  <div>{^users/mailto(subject: "Welcome to Jetzig!")}</div>
+
   <>Use fragment tags when you want to output content without a specific HTML tag</>
 
   <#>

--- a/src/templates/example_with_partial_with_argument_type_inference.zmpl
+++ b/src/templates/example_with_partial_with_argument_type_inference.zmpl
@@ -1,0 +1,2 @@
+<div>This is an example with a partial with arguments with type inference</div>
+<div>{^example_partial_with_inferred_arguments(foo: "hello", bar: 100, baz: 123.456, qux: true, quux: null)}</div>

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -29,6 +29,8 @@ test "readme example" {
             \\
             \\  <div><a href="mailto:user@example.com?subject=Welcome to Jetzig!">user@example.com</a></div>
             \\
+            \\  <div><a href="mailto:user@example.com?subject=Welcome to Jetzig!">user@example.com</a></div>
+            \\
             \\  Use fragment tags when you want to output content without a specific HTML tag
             \\
             \\  Use multi-line raw text tags to bypass Zmpl syntax.
@@ -410,6 +412,28 @@ test "template with partial with arguments" {
         \\<div><span>An example partial</span>
         \\<span>foo: hello</span>
         \\<span>bar: 100</span></div>
+        \\
+    ;
+    try std.testing.expectEqualStrings(expected, output);
+}
+
+test "template with partial with argument type inference" {
+    var data = zmpl.Data.init(allocator);
+    defer data.deinit();
+
+    const template = manifest.find("example_with_partial_with_argument_type_inference");
+    const output = try template.?.render(&data);
+    defer allocator.free(output);
+
+    // XXX: `null` (`quux`) coerces an empty string.
+    const expected =
+        \\<div>This is an example with a partial with arguments with type inference</div>
+        \\<div><span>An example partial</span>
+        \\<span>foo: hello</span>
+        \\<span>bar: 100</span>
+        \\<span>baz: 123.456</span>
+        \\<span>qux: true</span>
+        \\<span>quux: </span></div>
         \\
     ;
     try std.testing.expectEqualStrings(expected, output);

--- a/src/zmpl/Data.zig
+++ b/src/zmpl/Data.zig
@@ -254,7 +254,8 @@ pub fn boolean(self: *Self, value: bool) *Value {
     return val;
 }
 
-fn _null(self: *Self) *Value {
+/// Creates a new `Value` representing a `null` value. Public, but for internal use only.
+pub fn _null(self: *Self) *Value {
     const allocator = self.getAllocator();
     const val = allocator.create(Value) catch @panic("Out of memory");
     val.* = .{ .Null = NullType{} };
@@ -477,7 +478,7 @@ pub const Float = struct {
     }
 
     pub fn toString(self: Float) ![]const u8 {
-        return std.fmt.allocPrint(self.allocator, "{}", .{self.value});
+        return std.fmt.allocPrint(self.allocator, "{d}", .{self.value});
     }
 };
 


### PR DESCRIPTION
Allow users to pass untyped literals as partial args, use type inference to coerce to a Zmpl data type.