### PR TITLE
fixed getT(.array,) and getT(.object,)

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -449,3 +449,24 @@ test "inferred type in put/append" {
         try std.testing.expect(false);
     }
 }
+
+test "getT(.array, ...) and getT(.object, ...)" {
+    var data = zmpl.Data.init(std.testing.allocator);
+    defer data.deinit();
+    var root = try data.root(.object);
+    var obj = try data.object();
+    var arr = try data.array();
+    try arr.append(1);
+    try arr.append(2);
+
+    try obj.put("a", 1);
+    try obj.put("b", 2e0);
+
+    try root.put("test_struct", obj);
+    try root.put("test_list", arr);
+
+    const res_arr = root.getT(.array, "test_list").?;
+    const res_obj = root.getT(.object, "test_struct").?;
+    try std.testing.expectEqual(&arr.array, res_arr);
+    try std.testing.expectEqual(&obj.object, res_obj);
+}

--- a/src/zmpl/Data.zig
+++ b/src/zmpl/Data.zig
@@ -526,7 +526,7 @@ pub fn get(self: Data, key: []const u8) ?*Value {
 /// (e.g. `.string` returns `[]const u8`).
 pub fn getT(self: *const Data, comptime T: ValueType, key: []const u8) ?switch (T) {
     .object => *Object,
-    .array => []*const Value,
+    .array => *Array,
     .string => []const u8,
     .float => f128,
     .integer => i128,
@@ -984,7 +984,7 @@ pub const Object = struct {
 
     pub fn getT(self: Object, comptime T: ValueType, key: []const u8) ?switch (T) {
         .object => *Object,
-        .array => []*Value,
+        .array => *Array,
         .string => []const u8,
         .float => f128,
         .integer => i128,
@@ -995,11 +995,11 @@ pub const Object = struct {
             const value = entry.value_ptr.*.*;
             return switch (T) {
                 .object => switch (value) {
-                    .object => entry.value_ptr.*,
+                    .object => &entry.value_ptr.*.object,
                     else => null,
                 },
                 .array => switch (value) {
-                    .array => |capture| capture.array.items,
+                    .array => &entry.value_ptr.*.array,
                     else => null,
                 },
                 .string => switch (value) {


### PR DESCRIPTION
Returned types match return type.
