### PR TITLE
Fixes min zig version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@main
+        uses: mlugg/setup-zig@v2
 
       - name: Print Zig version
         run: zig version

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,6 @@
 .{
     .name = .zmpl,
     .version = "0.0.1",
-    .minimum_zig_version = "0.11.0",
     .fingerprint = 0xef2931206468149,
     .minimum_zig_version = "0.15.0-dev.355+206bd1ced",
     .dependencies = .{


### PR DESCRIPTION
My bad. Removes the duplicate `minimum_zig_version`.

Also `mlugg/setup-zig` is now released, we can pin it to v2. 