### PR TITLE
Nullable if evaluation

### DIFF
--- a/src/manifest/IfStatement.zig
+++ b/src/manifest/IfStatement.zig
@@ -42,9 +42,13 @@ pub fn render(self: IfStatement, writer: anytype) !void {
             const if_full = self.ast.ifSimple(node);
 
             const wrap_true = self.isWrapTrue(if_full.payload_token != null, if_full.ast.cond_expr);
-            if (wrap_true) try writer.writeAll(wrap_eql_open);
-            try self.writeNode(if_full.ast.cond_expr, writer);
-            if (wrap_true) try writer.writeAll(wrap_eql_close_true);
+            if (wrap_true) {
+                try writer.writeAll(wrap_eql_open);
+                try self.writeNode(if_full.ast.cond_expr, writer);
+                try writer.writeAll(wrap_eql_close_true);
+            } else {
+                try self.writeNode(if_full.ast.cond_expr, writer);
+            }
 
             try writer.writeAll(")");
             if (if_full.payload_token) |payload_token| {
@@ -169,7 +173,7 @@ inline fn isOperator(tag: std.zig.Ast.Node.Tag) bool {
 // `if` statement.
 fn isWrapTrue(self: IfStatement, has_payload: bool, node: std.zig.Ast.Node.Index) bool {
     if (has_payload or isOperator(self.ast.nodeTag(node))) return false;
-
+    
     return true;
 }
 

--- a/src/manifest/IfStatement.zig
+++ b/src/manifest/IfStatement.zig
@@ -173,7 +173,7 @@ inline fn isOperator(tag: std.zig.Ast.Node.Tag) bool {
 // `if` statement.
 fn isWrapTrue(self: IfStatement, has_payload: bool, node: std.zig.Ast.Node.Index) bool {
     if (has_payload or isOperator(self.ast.nodeTag(node))) return false;
-    
+
     return true;
 }
 

--- a/src/templates/nullable_if.zmpl
+++ b/src/templates/nullable_if.zmpl
@@ -1,0 +1,5 @@
+@if ($.clip.notes)
+The value is not null
+@else
+The value is null
+@end

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -904,18 +904,18 @@ test "nullable if" {
     // Test for nullable if statements:
     // - null and empty strings should be falsey
     // - non-empty strings should be truthy
-    
+
     // Test with null value - should be falsey
     {
         var data = zmpl.Data.init(std.testing.allocator);
         defer data.deinit();
-        
+
         var clip = try data.object();
         try clip.put("notes", null);
-        
+
         var root = try data.root(.object);
         try root.put("clip", clip);
-        
+
         if (zmpl.find("nullable_if")) |template| {
             const output = try template.render(&data, Context, .{}, &.{}, .{});
             try std.testing.expectEqualStrings("\nThe value is null\n", output);
@@ -923,18 +923,18 @@ test "nullable if" {
             try std.testing.expect(false);
         }
     }
-    
+
     // Test with non-null, non-empty string - should be truthy
     {
         var data = zmpl.Data.init(std.testing.allocator);
         defer data.deinit();
-        
+
         var clip = try data.object();
         try clip.put("notes", "Some notes");
-        
+
         var root = try data.root(.object);
         try root.put("clip", clip);
-        
+
         if (zmpl.find("nullable_if")) |template| {
             const output = try template.render(&data, Context, .{}, &.{}, .{});
             // Non-empty string should correctly evaluate as truthy
@@ -943,18 +943,18 @@ test "nullable if" {
             try std.testing.expect(false);
         }
     }
-    
+
     // Test with empty string - should be falsey like null
     {
         var data = zmpl.Data.init(std.testing.allocator);
         defer data.deinit();
-        
+
         var clip = try data.object();
         try clip.put("notes", "");
-        
+
         var root = try data.root(.object);
         try root.put("clip", clip);
-        
+
         if (zmpl.find("nullable_if")) |template| {
             const output = try template.render(&data, Context, .{}, &.{}, .{});
             try std.testing.expectEqualStrings("\nThe value is null\n", output);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -900,6 +900,70 @@ test "mix mardown and zig" {
     }
 }
 
+test "nullable if" {
+    // Test for nullable if statements:
+    // - null and empty strings should be falsey
+    // - non-empty strings should be truthy
+    
+    // Test with null value - should be falsey
+    {
+        var data = zmpl.Data.init(std.testing.allocator);
+        defer data.deinit();
+        
+        var clip = try data.object();
+        try clip.put("notes", null);
+        
+        var root = try data.root(.object);
+        try root.put("clip", clip);
+        
+        if (zmpl.find("nullable_if")) |template| {
+            const output = try template.render(&data, Context, .{}, &.{}, .{});
+            try std.testing.expectEqualStrings("\nThe value is null\n", output);
+        } else {
+            try std.testing.expect(false);
+        }
+    }
+    
+    // Test with non-null, non-empty string - should be truthy
+    {
+        var data = zmpl.Data.init(std.testing.allocator);
+        defer data.deinit();
+        
+        var clip = try data.object();
+        try clip.put("notes", "Some notes");
+        
+        var root = try data.root(.object);
+        try root.put("clip", clip);
+        
+        if (zmpl.find("nullable_if")) |template| {
+            const output = try template.render(&data, Context, .{}, &.{}, .{});
+            // Non-empty string should correctly evaluate as truthy
+            try std.testing.expectEqualStrings("\nThe value is not null\n", output);
+        } else {
+            try std.testing.expect(false);
+        }
+    }
+    
+    // Test with empty string - should be falsey like null
+    {
+        var data = zmpl.Data.init(std.testing.allocator);
+        defer data.deinit();
+        
+        var clip = try data.object();
+        try clip.put("notes", "");
+        
+        var root = try data.root(.object);
+        try root.put("clip", clip);
+        
+        if (zmpl.find("nullable_if")) |template| {
+            const output = try template.render(&data, Context, .{}, &.{}, .{});
+            try std.testing.expectEqualStrings("\nThe value is null\n", output);
+        } else {
+            try std.testing.expect(false);
+        }
+    }
+}
+
 test "if statement with indented HTML - if branch" {
     var data = zmpl.Data.init(std.testing.allocator);
     defer data.deinit();

--- a/src/zmpl.zig
+++ b/src/zmpl.zig
@@ -49,34 +49,34 @@ pub fn sanitize(writer: anytype, input: []const u8) !void {
 /// For example, `@if (foo.bar)` will be true if `foo.bar` is not null.
 pub fn isPresent(value: anytype) !bool {
     const T = @TypeOf(value);
-    
+
     // Handle null values
     if (T == @TypeOf(null)) return false;
-    
+
     // Handle optional values
     if (@typeInfo(T) == .optional) {
         if (value == null) return false;
         return try isPresent(value.?);
     }
-    
+
     // Handle ZmplValue
     if (comptime isZmplValue(T)) {
         return value.isPresent();
     }
-    
+
     // For booleans, return the value directly
     if (T == bool) return value;
-    
+
     // For strings, check if the string is not empty
     if (comptime std.meta.trait.isZigString(T)) {
         return value.len > 0;
     }
-    
+
     // For numbers, check if the value is not zero
     if (comptime std.meta.trait.isNumber(T)) {
         return value != 0;
     }
-    
+
     // Default to true for any other value that exists
     return true;
 }

--- a/src/zmpl.zig
+++ b/src/zmpl.zig
@@ -44,6 +44,47 @@ pub fn sanitize(writer: anytype, input: []const u8) !void {
     _ = try fmt.sanitize(input);
 }
 
+/// Check if a value is present for use in if conditions.
+/// This is used to make nullable values behave intuitively in if statements.
+/// For example, `@if (foo.bar)` will be true if `foo.bar` is not null.
+pub fn isPresent(value: anytype) !bool {
+    const T = @TypeOf(value);
+    
+    // Handle null values
+    if (T == @TypeOf(null)) return false;
+    
+    // Handle optional values
+    if (@typeInfo(T) == .optional) {
+        if (value == null) return false;
+        return try isPresent(value.?);
+    }
+    
+    // Handle ZmplValue
+    if (comptime isZmplValue(T)) {
+        return value.isPresent();
+    }
+    
+    // For booleans, return the value directly
+    if (T == bool) return value;
+    
+    // For strings, check if the string is not empty
+    if (comptime std.meta.trait.isZigString(T)) {
+        return value.len > 0;
+    }
+    
+    // For numbers, check if the value is not zero
+    if (comptime std.meta.trait.isNumber(T)) {
+        return value != 0;
+    }
+    
+    // Default to true for any other value that exists
+    return true;
+}
+
+pub fn refIsPresent(data: *Data, ref_key: []const u8) !bool {
+    return data.refPresence(ref_key);
+}
+
 test {
     std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
`null` value would now evaluate to `false`

This implementation now properly handles:
  - null values as falsey
  - non-null, non-empty strings as truthy
  - empty strings as falsey

So now we can easily do

```zig
// $.clip.notes is nullable string.

@if ($.clip.notes)
    <span>{{ .clip.notes }}</span>
@else
      No notes present.
@end
```
