### PR TITLE
fix readFileAlloc usage

### DIFF
--- a/src/manifest/util.zig
+++ b/src/manifest/util.zig
@@ -222,7 +222,7 @@ pub fn readFile(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []const u8)
             else => return err,
         }
     };
-    const content = std.fs.cwd().readFileAlloc(path, allocator, .limited64(stat.size));
+    const content = std.fs.cwd().readFileAlloc(allocator, path, @min(stat.size, std.math.maxInt(usize)));
     return content;
 }
 


### PR DESCRIPTION
Hi,

just came across this project and tried to compile it with zig 0.15.1, and I got two errors in manifest/util where readFileAlloc was used. Essentially:

- path and Allocator arguments were swapped
- .limited64 returns a "Limit" enum in 0.15.1 now, just do with `@min` directly what .limited64 actually does.

Now everything compiles fine :). 