### PR TITLE
Fix `std.heap.pageSize()` not being comptime-known

### DIFF
--- a/src/zmpl/debug.zig
+++ b/src/zmpl/debug.zig
@@ -80,7 +80,7 @@ fn debugSourceLocation(
     try source_file.interface.readSliceAll(content);
 
     var cursor: usize = 0;
-    var buf: [std.heap.pageSize()]u8 = undefined;
+    var buf: [std.heap.page_size_min]u8 = undefined;
     try source_file.seekTo(0);
     const source_line_number = outer: {
         while (cursor < from_position) {
@@ -122,7 +122,7 @@ fn findDebugLine(
 
     var cursor: usize = 0;
     var line: usize = 0;
-    var buf: [std.heap.pageSize()]u8 = undefined;
+    var buf: [std.heap.page_size_min]u8 = undefined;
     var position: usize = 0;
 
     var read_buffer: [256]u8 = undefined;


### PR DESCRIPTION
With some targets, e.g. tested with `aarch64-linux-musl`, `std.heap.pageSize()` is [not comptime-known in compiler version 0.16.0](https://ziglang.org/documentation/master/std/#std.heap.pageSize) and therefore returns an error:

```
zig-pkg/zmpl-0.0.1-SYFGBq-yAwCLE5V8niLARi8eny-pM3FuzEQ18yhcX7jo/src/zmpl/debug.zig:125:32: note: called at comptime from here
    var buf: [std.heap.pageSize()]u8 = undefined;
              ~~~~~~~~~~~~~~~~~^~
zig-pkg/zmpl-0.0.1-SYFGBq-yAwCLE5V8niLARi8eny-pM3FuzEQ18yhcX7jo/src/zmpl/debug.zig:125:32: note: types must be comptime-known
```

This patch uses `std.heap.page_size_min` which is always comptime-known (which `std.heap.pageSize()` conditionally returns at comptime).